### PR TITLE
Add interoperability with CGSM

### DIFF
--- a/MiniBasePatches.cs
+++ b/MiniBasePatches.cs
@@ -220,7 +220,7 @@ namespace MiniBase
         {
             public static void Postfix()
             {
-                if (!IsMiniBase())
+                if (!IsMiniBaseStartPlanetoid())
                     return;
                 Log("MinionSelectScreen_OnProceed_Patch Postfix");
                 int radius = (int)(Math.Max(Grid.WidthInCells, Grid.HeightInCells) * 1.5f);
@@ -234,7 +234,7 @@ namespace MiniBase
         {
             public static void Postfix(TemporalTear temporalTear)
             {
-                if (!IsMiniBase())
+                if (!IsMiniBaseCluster())
                     return;
 
                 Log("ClusterPOIManager_RegisterTemporalTear_Patch Postfix");
@@ -250,7 +250,7 @@ namespace MiniBase
             public static void Postfix()
             {
                 Log("Game_OnSpawn_Patch Postfix");
-                if (IsMiniBase())
+                if (IsMiniBaseCluster())
                 {
                     var immigration = Immigration.Instance;
                     const float SecondsPerDay = 600f;
@@ -267,7 +267,7 @@ namespace MiniBase
         {
             public static void Postfix(ref CarePackageInfo[] ___carePackages)
             {
-                if (!IsMiniBase())
+                if (!IsMiniBaseCluster())
                     return;
                 Log("Immigration_ConfigureCarePackages_Patch Postfix");
                 // Add new care packages
@@ -278,7 +278,7 @@ namespace MiniBase
                 }
                 void AddItem(string name, float amount, int cycle = -1)
                 {
-                    packageList.Add(new CarePackageInfo(name, amount, cycle < 0 ? IsMiniBase : (Func<bool>)(() => CycleCondition(cycle) && IsMiniBase())));
+                    packageList.Add(new CarePackageInfo(name, amount, cycle < 0 ? IsMiniBaseCluster : (Func<bool>)(() => CycleCondition(cycle) && IsMiniBaseCluster())));
                 }
 
                 // Minerals
@@ -329,7 +329,7 @@ namespace MiniBase
         {
             public static void Postfix(ref bool __result)
             {
-                if (IsMiniBase())
+                if (IsMiniBaseCluster())
                     __result = true;
             }
         }
@@ -388,12 +388,12 @@ namespace MiniBase
             {
                 Log("WorldGen_RenderOffline_Patch Prefix");
                 // Skip the original method if on minibase world
-                return !IsMiniBase();
+                return !IsMiniBasePlanetoid(__instance);
             }
 
             public static void Postfix(WorldGen __instance, ref bool __result, bool doSettle, ref Sim.Cell[] cells, ref Sim.DiseaseCell[] dc, int baseId, ref List<WorldTrait> placedStoryTraits, bool isStartingWorld)
             {
-                if (!IsMiniBase())
+                if (!IsMiniBasePlanetoid(__instance))
                     return;
                 Log("WorldGen_RenderOffline_Patch Postfix");
                 __result = MiniBaseWorldGen.CreateWorld(__instance, ref cells, ref dc, baseId, ref placedStoryTraits);

--- a/MiniBaseUtils.cs
+++ b/MiniBaseUtils.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using UnityEngine;
+using ProcGenGame;
 using Klei.CustomSettings;
 using static MiniBase.MiniBaseConfig;
 
@@ -7,9 +8,33 @@ namespace MiniBase
 {
     class MiniBaseUtils
     {
-        public static bool IsMiniBase()
+        public static bool IsMiniBaseCluster()
         {
             return CustomGameSettings.Instance.GetCurrentQualitySetting(CustomGameSettingConfigs.ClusterLayout).id == ("clusters/" + ClusterName);
+        }
+
+        public static bool IsMiniBaseStartPlanetoid()
+        {
+	    var clusterLayout = SaveLoader.Instance.ClusterLayout;
+            foreach (WorldGen world in clusterLayout.worlds) {
+                if (!world.isStartingWorld) {
+                    continue;
+                }
+
+                return IsMiniBasePlanetoid(world);
+            }
+
+            return false;
+        }
+
+        public static bool IsMiniBasePlanetoid(WorldGen gen)
+        {
+            bool is_main = gen.Settings.world.filePath == "worlds/MiniBase";
+            bool is_second = gen.Settings.world.filePath == "worlds/BabyOilyMoonlet";
+            bool is_tree = gen.Settings.world.filePath == "worlds/BabyMarshyMoonlet";
+            bool is_niobium = gen.Settings.world.filePath == "worlds/BabyNiobiumMoonlet";
+
+	    return (is_main || is_second || is_tree || is_niobium);
         }
 
         public static void Log(string msg, bool force = false)


### PR DESCRIPTION
MiniBaseSO adds custom world generation & other hooks that currently only trigger when the player has selected the MiniBase cluster from the destination selection screen. This commit broadens a subset of these hooks to trigger more generally when a non-MiniBase cluster contains a MiniBase start world or when a non-MiniBase cluster contains any of the 4 MiniBase custom worlds. This will enable CGSM customized clusters to include MiniBase worlds once CGSM has been updated to include these new worlds. CGSM references:

https://github.com/mikeb26/ONIMods/tree/main/CGSM
https://steamcommunity.com/sharedfiles/filedetails/?id=2945098028
